### PR TITLE
Fix yagni link in "over modularization" pattern

### DIFF
--- a/_patterns/over_modularization.md
+++ b/_patterns/over_modularization.md
@@ -27,7 +27,7 @@ Software projects are divided into several modules at run time (e.g. services, l
 
 ## How can we avoid getting into the situation in the first place?
 - Try to have few meaningful modules which emphasize important architectural boundaries. Cut your modules by bounded contexts. (Domain-driven Design)
-- [Yagni]: Don't split your project into more modules until you need to.
+- [Yagni](https://www.martinfowler.com/bliki/Yagni.html): Don't split your project into more modules until you need to.
 - Reevaluate the project's modularization periodically and refactor your software accordingly. Start early, later will be harder.
 
 


### PR DESCRIPTION
ATM the whole yagni line is dropped on the rendered HTML page. This change is an idea how the missing rendering could be fixed. Also the yagni description at the end of the page is missing. Maybe due to the same reason. Maybe there is another idea/way to fix it. :)