### PR TITLE
added footer link to imprint and csv gem for build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,7 @@ end
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
-gem "webrick"
+gem "webrick", "~> 1.8"
+
+gem "csv"
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,7 @@
         <p>It is published under <a class="footer__textlink" href="https://creativecommons.org/licenses/by/4.0/" target="_blank">Creative Commons
                 Attribution 4.0 International Public License</a> and can therefore be shared and adapted with
             attribution ("INNOQ").</p>
+        <p><a class="footer__textlink" href="https://www.innoq.com/en/impressum/">Imprint</a></p>
         <p class="footer__subtitle"> Made and maintained by </p>
         <a href="https://www.innoq.com">
             <img class="footer__logo" src="{{ site.baseurl }}/lib/img/innoq-logo--white.svg" alt="INNOQ Logo" />


### PR DESCRIPTION
We need to have a site notice / imprint. 
Also i needed to include a csv lib:
```bash
You can add logger to your Gemfile or gemspec to silence this warning.
/opt/homebrew/lib/ruby/gems/3.4.0/gems/jekyll-3.9.5/lib/jekyll.rb:28: warning: csv was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
```